### PR TITLE
Change label.switch-text styles in section.switch-box (Classrooms.css)

### DIFF
--- a/src/Classrooms/Classrooms.css
+++ b/src/Classrooms/Classrooms.css
@@ -35,10 +35,9 @@
 
 .switch-text {
     padding: 0;
-    width:70%;
+    width: 170px;
     font-weight: 700;
-    display: flex;
-    justify-content: center;
+    text-align: center;
 }
 
 .switch {


### PR DESCRIPTION
Se cambió la ubicación del elemento `label` con la clase `switch-text` que se encuentra dentro de la sección con clase `switch-box`. Esto con el fin de mejorar la UI y la UX ya que en computadoras el elemento antes mencionado se encuentra posicionado a la izquierda del todo. Es un cambio super pequeño en los estilos y no afecta nada más 😊.